### PR TITLE
Upgrade core.async to version that is 1.9 compatible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.2.395"]]
+                 [org.clojure/core.async "0.3.443"]]
   :profiles
   {:lab
    {:source-paths ["src" "lab"]


### PR DESCRIPTION
core.async 0.2.395 will not compile under the clojure 1.9 betas. This should be a safe update because there was no breaking changes between these versions.