### PR TITLE
Eliminate compiler warnings in ClojureScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- file names properly captured when using CLJS (also clean up some CLJS compilation warnings).
+
 ## 0.1.4 - 2017-10-19
 ### Added
 - sc.api now requires its own macros in CLJS, making it easier to use in ClojureScript

--- a/src/sc/impl.cljc
+++ b/src/sc/impl.cljc
@@ -111,7 +111,7 @@
   (let [ep (save-v ep-id error? v)]
     (try
       (log-v ep)
-      (catch Throwable err nil)))
+      (catch #?(:clj Throwable :cljs :default) err nil)))
   nil)
 
 (defn emit-save-scope

--- a/src/sc/impl.cljc
+++ b/src/sc/impl.cljc
@@ -71,7 +71,10 @@
        amp-env amp-form expr)
      :sc.cs/dynamic-var-names
      (get opts :sc/dynamic-vars nil)
-     :sc.cs/file *file*                                     ;; TODO is this portable? (Val, 02 Oct 2017)
+     :sc.cs/file #?(:clj (case (compilation-target amp-env)
+                           :clj *file*
+                           :cljs (:file fm))
+                    :cljs (:file fm))
      :sc.cs/line (:line fm)
      :sc.cs/column (:column fm)}))
 


### PR DESCRIPTION
Following up on https://github.com/vvvvalvalval/scope-capture/issues/18

The warning about `Throwable` is very easy to get rid of (see diff).

The warning about the `*file*` dynamic variable less so... I don't know much about it except its [doc](https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/*file*). All I've learned for now is that earmuffs are **really** inconvenient when you look for them in search engines :sweat_smile: . I will dig deeper in the following days.



By the way, I use the following command to test the self-hosted clojurescript case (very primitive but convenient): 

```sh
# at the root of the project
lumo --classpath src/ \
     --eval "(require '[sc.api :as sc]) (let [a 42] (sc/spy)) (sc/letsc [1 -1] (assert (= a 42)))"
```

