### PR TITLE
Fix `dispose-all!` by using keys from `:execution-points` map as ids

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vvvvalvalval/scope-capture "0.2.0"
+(defproject vvvvalvalval/scope-capture "0.2.1-SNAPSHOT"
   :description "Easier REPL-based debugging for Clojure by saving and restoring snapshots of the local environment."
   :url "https://github.com/vvvvalvalval/scope-capture"
   :license {:name "MIT"

--- a/src/sc/impl.cljc
+++ b/src/sc/impl.cljc
@@ -348,7 +348,7 @@
 (defn dispose-all!
   []
   (->> @db/db :execution-points
-    (map :sc.ep/id)
+    keys
     (run! dispose!)))
 
 (defn save-ep


### PR DESCRIPTION
This should fix following error:

```
(sc/dispose-all!)
ExceptionInfo ep-id should be either a positive number or a [(positive-number) (negative-number)] tuple, got: nil  clojure.core/ex-info (core.clj:4739)
```